### PR TITLE
Lowercase yii app language as a default

### DIFF
--- a/TranslateableBehavior.php
+++ b/TranslateableBehavior.php
@@ -171,7 +171,7 @@ class TranslateableBehavior extends Behavior
     public function getLanguage()
     {
         if ($this->_language === null) {
-            $this->_language = Yii::$app->language;
+            $this->_language = strtolower(Yii::$app->language);
         }
         return $this->_language;
     }


### PR DESCRIPTION
setLanguage() changes the case of set language to lowercase when called, but when behaviour is initialized it sets Yii apps language without case modifications. For example if default language code is 'lv-LV' model with this code is created initially, then, when setLanguage('lv-LV') will be called it will cause another model instance to be created and all the modifications to previous model will be gone..