### PR TITLE
Allow configuration for behavior about deleting translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ You may configure `'deleteEvent'` to be either `ActiveRecord::EVENT_BEFORE_DELET
 control on which event the deletion of records should be performed.
 You may set `'deleteEvent'` to `false` to disable deletion and rely on DB foreign key cascade or implement your own method.
 
+When using the Translateablebehavior in an ActiveRecord you should enable [transactions()](https://www.yiiframework.com/doc/api/2.0/yii-db-activerecord#transactions()-detail)
+for the delete operation.
+
 > [![2amigOS!](http://www.gravatar.com/avatar/55363394d72945ff7ed312556ec041e0.png)](http://www.2amigos.us)  
 <i>Web development has never been so fun!</i>  
 [www.2amigos.us](http://www.2amigos.us)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ in Yii DI container:
 Yii::$container->set('dosamigos\translateable\TranslateableBehavior', ['fallbackLanguage' => 'de']);
 ```
 
+
+### Deleting translations
+
+By default, when an active record is deleted, translation records are deleted in the `afterSave` event.
+However some database scenarios require different configuration, in case foreign keys restrict the deletion of records.
+
+You may configure `'deleteEvent'` to be either `ActiveRecord::EVENT_BEFORE_DELETE` or `ActiveRecord::EVENT_AFTER_DELETE` to
+control on which event the deletion of records should be performed.
+You may set `'deleteEvent'` to `false` to disable deletion and rely on DB foreign key cascade or implement your own method.
+
 > [![2amigOS!](http://www.gravatar.com/avatar/55363394d72945ff7ed312556ec041e0.png)](http://www.2amigos.us)  
 <i>Web development has never been so fun!</i>  
 [www.2amigos.us](http://www.2amigos.us)

--- a/TranslateableBehavior.php
+++ b/TranslateableBehavior.php
@@ -48,6 +48,7 @@ class TranslateableBehavior extends Behavior
      * this translation will not be saved unless changes were made.
      * This helps to reduce duplicate entries in the database and allows save records even
      * if it has not been translated. Defaults to `false`, which means translations will always be saved.
+     * @since 1.0.4
      */
     public $skipSavingDuplicateTranslation = false;
 
@@ -55,6 +56,7 @@ class TranslateableBehavior extends Behavior
      * @var string the ActiveRecord event to perform deletion of related translation records if a record is deleted.
      * The default is `ActiveRecord::EVENT_AFTER_DELETE`.
      * You may set this to `false` to disable deletion and rely on DB foreign key cascade or implement your own method.
+     * @since 1.0.5
      */
     public $deleteEvent = ActiveRecord::EVENT_AFTER_DELETE;
 
@@ -72,6 +74,7 @@ class TranslateableBehavior extends Behavior
      *
      * This property will only be used when `$deleteEvent` is `ActiveRecord::EVENT_BEFORE_DELETE` as it needs to prevent
      * deletion of the record, which is only possible before deletion.
+     * @since 1.0.5
      */
     public $restrictDeletion = self::DELETE_ALL;
 


### PR DESCRIPTION
- Allow configuration of afterDelete event 
- implement $restrictDeletion property, to prevent deletion of records with multiple translations

default behavior does not change, it just go more flexible by allowing more configuration.