### PR TITLE
fixed modelEqualsFallbackTranslation with "empty" values edge case

### DIFF
--- a/TranslateableBehavior.php
+++ b/TranslateableBehavior.php
@@ -341,7 +341,7 @@ class TranslateableBehavior extends Behavior
         foreach ($this->_models as $language => $model) {
             $dirty = $model->getDirtyAttributes();
             // we do not need to save anything, if nothing has changed or translation is equal to its fallback
-            if (empty($dirty) || $this->skipSavingDuplicateTranslation && $model->isNewRecord && $this->modelEqualsFallbackTranslation($model, $language)) {
+            if (empty($dirty) || ($this->skipSavingDuplicateTranslation && $model->isNewRecord && $this->modelEqualsFallbackTranslation($model, $language))) {
                 continue;
             }
             /** @var \yii\db\ActiveQuery $relation */
@@ -376,7 +376,7 @@ class TranslateableBehavior extends Behavior
     {
         $fallbackLanguage = $this->getFallbackLanguage($language);
         foreach($this->translationAttributes as $translationAttribute) {
-            if (!empty($model->$translationAttribute)) {
+            if (isset($model->$translationAttribute)) {
                 list($translation, $transLanguage) = $this->getAttributeTranslation($translationAttribute, $fallbackLanguage);
                 if ($transLanguage === $language || $model->$translationAttribute !== $translation) {
                     return false;


### PR DESCRIPTION
This PR fixed an edge case we found:

if `skipSavingDuplicateTranslation` is set to `true` and all translationAttributes have values that PHP considers "empty" in `empty()`, no translation is created even when creating a new record.

To fix this, in `modelEqualsFallbackTranslation()` we should only check the presence of `$model->$translationAttribute` with `isset()`, not the value with `emtpy()`.

Our usecase are translation tables in which we store only a translatable active/inactive `status` attribute of a base model as 0|1 values with default set to 0.

I also added a test which try to cover these edgeCase and where you can see where the problem can occur.

Cc: @cebe @schmunk42 
